### PR TITLE
Install the method CategoryOfQuiverRepresentationsOverVectorSpaceCategory with cache

### DIFF
--- a/lib/representation.gi
+++ b/lib/representation.gi
@@ -893,7 +893,7 @@ function( cat1, cat2 )
          and VectorSpaceCategory( cat1 ) = VectorSpaceCategory( cat2 );
 end );
 
-InstallMethod( CategoryOfQuiverRepresentationsOverVectorSpaceCategory,
+InstallMethodWithCache( CategoryOfQuiverRepresentationsOverVectorSpaceCategory,
                "for quiver algebra and vector space category",
                [ IsQuiverAlgebra, IsAbelianCategory ],
 function( A, vecspace_cat )


### PR DESCRIPTION
`CategoryOfQuiverRepresentationsOverVectorSpaceCategory ` with cache in order to avoid constructing a new category at each call.

It would be better to have this commit here until my similar PR is merged into the Oysteins repository.
